### PR TITLE
Streamline docstrings, add @classmethod, and clean formatting

### DIFF
--- a/semantiva_imaging/data_io/io.py
+++ b/semantiva_imaging/data_io/io.py
@@ -8,9 +8,6 @@ from ..data_types import ImageDataType, ImageStackDataType
 class ImageDataSource(DataSource):
     """
     Abstract base class for image data sources.
-
-    This class provides an interface for retrieving `ImageDataType` objects from a source.
-    Subclasses must implement the `_get_data` method to define how the data is retrieved.
     """
 
     @abstractmethod
@@ -46,9 +43,6 @@ class ImageDataSource(DataSource):
 class ImageStackSource(DataSource):
     """
     Abstract base class for image stack data sources.
-
-    This class provides an interface for retrieving `ImageStackDataType` objects from a source.
-    Subclasses must implement the `_get_data` method to define how the data is retrieved.
     """
 
     @abstractmethod
@@ -82,9 +76,6 @@ class ImageStackSource(DataSource):
 class ImageDataSink(DataSink):
     """
     Abstract base class for image data sinks.
-
-    This class provides an interface for consuming and storing `ImageDataType` objects.
-    Subclasses must implement the `_send_data` method to define how the data is stored or processed.
     """
 
     @abstractmethod
@@ -117,9 +108,6 @@ class ImageDataSink(DataSink):
 class ImageStackDataSink(DataSink):
     """
     Abstract base class for image stack data sinks.
-
-    This class provides an interface for consuming and storing `ImageStackDataType` objects.
-    Subclasses must implement the `_send_data` method to define how the data is stored or processed.
     """
 
     @abstractmethod
@@ -152,10 +140,6 @@ class ImageStackDataSink(DataSink):
 class ImagePayloadSink(PayloadSink):
     """
     Abstract base class for sinks that consume and store `ImageDataType` objects with associated context.
-
-    This class provides an interface for consuming and storing `ImageDataType` objects along with
-    their associated context. Subclasses must implement the `_send_payload` method to define how
-    the data and context are stored or processed.
     """
 
     @abstractmethod
@@ -197,10 +181,6 @@ class ImagePayloadSink(PayloadSink):
 class ImageStackPayloadSource(PayloadSource):
     """
     Abstract base class for sources that provide `ImageStackDataType` objects with associated context.
-
-    This class provides an interface for generating and supplying `ImageStackDataType` objects
-    along with their associated context. Subclasses must implement the `_get_payload` method to
-    define how the data and context are generated or retrieved.
     """
 
     @abstractmethod

--- a/semantiva_imaging/data_io/loaders_savers.py
+++ b/semantiva_imaging/data_io/loaders_savers.py
@@ -280,14 +280,6 @@ class PNGImageStackSaver(ImageStackDataSink):
 class ImageDataRandomGenerator(ImageDataSource):
     """
     A random generator for creating `ImageDataType` objects with random data.
-
-    This class is used to generate dummy image data for testing and development purposes.
-    The generated data is a 2D NumPy array of random values between 0 and 1, wrapped in an
-    `ImageDataType` object.
-
-    Methods:
-        _get_data(shape: tuple[int, int]) -> ImageDataType:
-            Generates a dummy `ImageDataType` with the specified shape.
     """
 
     def _get_data(self, shape: tuple[int, int]) -> ImageDataType:
@@ -445,14 +437,6 @@ class ParametricImageStackGenerator(ImageStackSource):
 class ImageStackRandomGenerator(ImageStackSource):
     """
     A random generator for creating `ImageStackDataType` objects with random data.
-
-    This class is used to generate dummy image stack data for testing and development purposes.
-    The generated data is a 3D NumPy array of random values between 0 and 1, wrapped in an
-    `ImageStackDataType` object.
-
-    Methods:
-        _get_data(shape: tuple[int, int, int]) -> ImageStackDataType:
-            Generates a dummy `ImageStackDataType` with the specified shape.
     """
 
     def _get_data(self, shape: tuple[int, int, int]) -> ImageStackDataType:
@@ -481,18 +465,10 @@ class ImageStackRandomGenerator(ImageStackSource):
 class ImageStackPayloadRandomGenerator(ImageStackPayloadSource):
     """
     A random generator for producing payloads containing ImageStackDataType and ContextType.
-
-    This class generates dummy payloads for testing purposes or as a placeholder
-    in pipelines where input data is not yet available. The generated payloads
-    contain an `ImageStackDataType` object with random or placeholder data and an
-    associated `ContextType`.
-
-    Methods:
-        get_payload(*args, **kwargs) -> tuple[ImageStackDataType, ContextType]:
-            Generates and returns a dummy payload.
     """
 
-    def _injected_context_keys(self) -> List[str]:
+    @classmethod
+    def _injected_context_keys(cls) -> List[str]:
         """
         Returns a list of context keys that are injected into the payload.
 

--- a/semantiva_imaging/data_types/data_types.py
+++ b/semantiva_imaging/data_types/data_types.py
@@ -5,17 +5,7 @@ from semantiva.data_types import BaseDataType, DataCollectionType
 
 class ImageDataType(BaseDataType[np.ndarray]):
     """
-    A class representing a 2D image data type, derived from BaseDataType.
-
-    This class ensures that the input data is a 2D NumPy array and provides validation
-    to enforce this constraint.
-
-    Attributes:
-        data (numpy.ndarray): The image data, represented as a 2D NumPy array.
-
-    Methods:
-        validate(data: numpy.ndarray):
-            Validates that the input data is a 2D NumPy array.
+    A class representing a 2D image.
     """
 
     def __init__(self, data: np.ndarray, *args, **kwargs):
@@ -54,16 +44,6 @@ class ImageDataType(BaseDataType[np.ndarray]):
 class ImageStackDataType(DataCollectionType[ImageDataType, np.ndarray]):
     """
     A class representing a stack of image data, derived from DataCollection.
-
-    This class is designed to handle multi-dimensional image data (e.g., a stack of 2D images)
-    and provides validation to ensure that the input is a NumPy array.
-
-    Attributes:
-        data (numpy.ndarray): The image stack data, represented as an N-dimensional NumPy array.
-
-    Methods:
-        validate(data: numpy.ndarray):
-            Validates that the input data is an N-dimensional NumPy array.
     """
 
     def __init__(self, data: Optional[np.ndarray] = None):

--- a/semantiva_imaging/probes/probes.py
+++ b/semantiva_imaging/probes/probes.py
@@ -7,10 +7,7 @@ from ..data_types import ImageDataType
 
 class BasicImageProbe(ImageProbe):
     """
-    A basic image probe that computes essential image statistics.
-
-    This class provides a simple probe to calculate key statistical properties of an image,
-    such as mean, sum, minimum value, and maximum value.
+    A basic image probe that computes mean, sum, minimum and maximum pixel values.
     """
 
     def _process_logic(self, data):

--- a/semantiva_imaging/processing/operations.py
+++ b/semantiva_imaging/processing/operations.py
@@ -11,15 +11,7 @@ from ..processing.processors import (
 
 class ImageSubtraction(ImageOperation):
     """
-    A class for performing image subtraction.
-
-    This class inherits from `ImageOperation` and implements an operation
-    to subtract one image from another. Both images must be instances of
-    `ImageDataType`, ensuring that they are 2D NumPy arrays.
-
-    Methods:
-        _operation(data: ImageDataType, subtracting_image: ImageDataType) -> ImageDataType:
-            Performs the subtraction operation between the input image and the subtracting image.
+    Substracts one image from another.
     """
 
     def _process_logic(
@@ -40,15 +32,7 @@ class ImageSubtraction(ImageOperation):
 
 class ImageAddition(ImageOperation):
     """
-    A class for performing image addition.
-
-    This class inherits from `ImageOperation` and implements an operation
-    to add one image to another. Both images must be instances of
-    `ImageDataType`, ensuring that they are 2D NumPy arrays.
-
-    Methods:
-        _operation(data: ImageDataType, added_image: ImageDataType) -> ImageDataType:
-            Performs the addition operation between the input image and the added image.
+    Adds two images together.
     """
 
     def _process_logic(
@@ -69,10 +53,7 @@ class ImageAddition(ImageOperation):
 
 class ImageCropper(ImageOperation):
     """
-    A class for cropping a region from an image.
-
-    This class inherits from `ImageOperation` and implements an operation
-    to crop a rectangular region from the input image.
+    Crops a rectangular region from the input image.
     """
 
     def _process_logic(
@@ -116,8 +97,7 @@ class ImageCropper(ImageOperation):
 
 class StackToImageMeanProjector(ImageStackToImageProjector):
     """
-    A concrete implementation of ImageStackFlattener that projects a stack of images
-    into a single image by taking the mean along the slices.
+    Projects a stack of images into a single image by computing the mean pixel value among the slices.
     """
 
     def _process_logic(self, data: ImageStackDataType) -> ImageDataType:
@@ -141,11 +121,8 @@ class StackToImageMeanProjector(ImageStackToImageProjector):
 
 class ImageNormalizerOperation(ImageOperation):
     """
-    A class to normalize image data to a specified range.
+    Linear normalization of an image data to a specified range.
 
-    This class inherits from the `ImageOperation` base class and performs
-    normalization on image data, scaling pixel values linearly to fit
-    within a given range `[min_value, max_value]`.
     """
 
     def _process_logic(
@@ -182,8 +159,7 @@ class ImageNormalizerOperation(ImageOperation):
 
 class ImageStackToSideBySideProjector(ImageStackToImageProjector):
     """
-    A concrete implementation of ImageStackToImageProjector that projects a stack of images
-    into a single image by concatenating the images side by side.
+    Projects a stack of images into a single image by concatenating the images side by side.
     """
 
     def _process_logic(self, data: ImageStackDataType) -> ImageDataType:

--- a/semantiva_imaging/processing/processors.py
+++ b/semantiva_imaging/processing/processors.py
@@ -4,14 +4,7 @@ from ..data_types import ImageDataType, ImageStackDataType
 
 class ImageOperation(DataOperation):
     """
-    An operation specialized for processing ImageDataType data.
-
-    This class implements the `DataOperation` abstract base class to define
-    operations that accept and produce `ImageDataType`.
-
-    Methods:
-        input_data_type: Returns the expected input data type.
-        output_data_type: Returns the type of data output by the operation.
+    A DataOperation for ImageDataType data.
     """
 
     @classmethod
@@ -37,14 +30,7 @@ class ImageOperation(DataOperation):
 
 class ImageStackAlgorithm(DataOperation):
     """
-    An operation specialized for processing ImageStackDataType data.
-
-    This class implements the `DataOperation` abstract base class to define
-    operations that accept and produce `ImageStackDataType`.
-
-    Methods:
-        input_data_type: Returns the expected input data type.
-        output_data_type: Returns the type of data output by the operation.
+    A DataOperation for ImageStackDataType data.
     """
 
     @classmethod
@@ -70,14 +56,7 @@ class ImageStackAlgorithm(DataOperation):
 
 class ImageStackToImageProjector(DataOperation):
     """
-    An operation specialized for flattening ImageStackDataType data.
-
-    This class implements the `DataOperation` abstract base class to define
-    operations that accept `ImageStackDataType` and produce `ImageDataType`.
-
-    Methods:
-        input_data_type: Returns the expected input data type.
-        output_data_type: Returns the type of data output by the operation.
+    A DataOperation for flattening ImageStackDataType data into a ImageDataType.
     """
 
     @classmethod
@@ -103,13 +82,7 @@ class ImageStackToImageProjector(DataOperation):
 
 class ImageProbe(DataProbe):
     """
-    A probe for inspecting or monitoring ImageDataType data.
-
-    This class implements the `DataProbe` abstract base class to define
-    operations that accept and produce `ImageDataType`.
-
-    Methods:
-        input_data_type: Returns the expected input data type.
+    A DataProbe for ImageDataType data.
     """
 
     @classmethod
@@ -125,13 +98,7 @@ class ImageProbe(DataProbe):
 
 class ImageStackProbe(DataProbe):
     """
-    A probe for inspecting or monitoring ImageStackDataType data.
-
-    This class implements the `DataProbe` abstract base class to define
-    operations that accept and produce `ImageStackDataType`.
-
-    Methods:
-        input_data_type: Returns the expected input data type.
+    A DataProbe for ImageStackDataType data.
     """
 
     @classmethod

--- a/semantiva_imaging/visualization/viewers.py
+++ b/semantiva_imaging/visualization/viewers.py
@@ -22,7 +22,7 @@ class FigureOption(TypedDict):
 
 class ImageViewer:
     """
-    A concrete implementation that processes an image with customizable settings.
+    ImageDataType viewer.
     """
 
     @classmethod
@@ -201,10 +201,7 @@ class ImageInteractiveViewer:
 
 class ImageStackAnimator:
     """
-    A concrete implementation that processes an image stack into an animation.
-
-    The generated animation cycles through each image in the stack, allowing visualization of
-    dynamic or sequential image data.
+    A viewer that animates an ImageStackType object
     """
 
     @classmethod

--- a/tests/test_image_pipeline.py
+++ b/tests/test_image_pipeline.py
@@ -6,10 +6,6 @@ from semantiva_imaging.data_types import (
     ImageDataType,
 )
 from semantiva.payload_operations import Pipeline
-from semantiva_imaging.processing.operations import (
-    ImageAddition,
-    StackToImageMeanProjector,
-)
 from semantiva_imaging.data_io.loaders_savers import (
     ImageDataRandomGenerator,
     ImageStackRandomGenerator,

--- a/tests/test_image_pipeline_slicing.py
+++ b/tests/test_image_pipeline_slicing.py
@@ -82,24 +82,32 @@ def test_pipeline_slicing_with_single_context(
 
     node_configurations = [
         {
-            "processor": Slicer(ImageAddition, ImageStackDataType),  # Adds a specified image to each slice of the input data
+            "processor": Slicer(
+                ImageAddition, ImageStackDataType
+            ),  # Adds a specified image to each slice of the input data
             "parameters": {
                 "image_to_add": random_image
             },  # Image to be added to each slice
         },
         {
-            "processor": Slicer(ImageSubtraction, ImageStackDataType),  # Subtracts a specified image from each slice of the input data
+            "processor": Slicer(
+                ImageSubtraction, ImageStackDataType
+            ),  # Subtracts a specified image from each slice of the input data
             "parameters": {
                 "image_to_subtract": another_random_image
             },  # Image to subtract
         },
         {
-            "processor": Slicer(BasicImageProbe, ImageStackDataType),  # Probe operation to extract and store data
+            "processor": Slicer(
+                BasicImageProbe, ImageStackDataType
+            ),  # Probe operation to extract and store data
             "context_keyword": "mock_keyword",  # Stores probe results under this keyword in the context
             "parameters": {},  # No extra parameters required (can be omitted)
         },
         {
-            "processor": Slicer(BasicImageProbe, ImageStackDataType),  # Probe operation to collect results
+            "processor": Slicer(
+                BasicImageProbe, ImageStackDataType
+            ),  # Probe operation to collect results
             "parameters": {},  # No extra parameters required (can be omitted)
             # No `context_keyword`, making this node a ProbeCollectorNode (results stored internally)
         },
@@ -108,9 +116,9 @@ def test_pipeline_slicing_with_single_context(
     pipeline = Pipeline(node_configurations)
 
     output_data, output_context = pipeline.process(random_image_stack, random_context)
-    assert len(pipeline.get_probe_results()["Node 4/SlicerForBasicImageProbe"][0]) == len(
-        output_data
-    )
+    assert len(
+        pipeline.get_probe_results()["Node 4/SlicerForBasicImageProbe"][0]
+    ) == len(output_data)
 
     assert len(output_data) == len(
         output_context.get_value("mock_keyword")
@@ -138,24 +146,32 @@ def test_pipeline_slicing_with_context_collection(
 
     node_configurations = [
         {
-            "processor": Slicer(ImageAddition, ImageStackDataType),  # Adds a specified image to each slice of the input data
+            "processor": Slicer(
+                ImageAddition, ImageStackDataType
+            ),  # Adds a specified image to each slice of the input data
             "parameters": {
                 "image_to_add": random_image
             },  # Image to be added to each slice
         },
         {
-            "processor": Slicer(ImageSubtraction, ImageStackDataType),  # Subtracts a specified image from each slice of the input data
+            "processor": Slicer(
+                ImageSubtraction, ImageStackDataType
+            ),  # Subtracts a specified image from each slice of the input data
             "parameters": {
                 "image_to_subtract": another_random_image
             },  # Image to subtract
         },
         {
-            "processor": Slicer(BasicImageProbe, ImageStackDataType),  # Probe operation to extract and store data
+            "processor": Slicer(
+                BasicImageProbe, ImageStackDataType
+            ),  # Probe operation to extract and store data
             "context_keyword": "mock_keyword",  # Stores probe results under this keyword in the context
             "parameters": {},  # No extra parameters required (can be omitted)
         },
         {
-            "processor": Slicer(BasicImageProbe, ImageStackDataType),  # Probe operation to collect results
+            "processor": Slicer(
+                BasicImageProbe, ImageStackDataType
+            ),  # Probe operation to collect results
             "parameters": {},  # No extra parameters required (can be omitted)
             # No `context_keyword`, making this node a ProbeCollectorNode (results stored internally)
         },
@@ -172,9 +188,9 @@ def test_pipeline_slicing_with_context_collection(
         random_image_stack, random_context_collection
     )
 
-    assert len(pipeline.get_probe_results()["Node 4/SlicerForBasicImageProbe"][0]) == len(
-        output_data
-    )
+    assert len(
+        pipeline.get_probe_results()["Node 4/SlicerForBasicImageProbe"][0]
+    ) == len(output_data)
     assert isinstance(
         output_data, ImageStackDataType
     ), "Output should be an ImageStackDataType"


### PR DESCRIPTION
- Removed redundant boilerplate text from abstract base class docstrings, retaining only concise descriptions.
- Annotated `_injected_context_keys` in `ImageStackPayloadRandomGenerator` with `@classmethod`.