### PR TITLE
[issue-47] Renamed single-channel base classes to explicitly mention the channel

### DIFF
--- a/semantiva_imaging/probes/__init__.py
+++ b/semantiva_imaging/probes/__init__.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 from .probes import (
-    ImageProbe,
+    SingleChannelImageProbe,
     BasicImageProbe,
     TwoDGaussianFitterProbe,
     TwoDTiltedGaussianFitterProbe,
 )
 
 __all__ = [
-    "ImageProbe",
+    "SingleChannelImageProbe",
     "BasicImageProbe",
     "TwoDGaussianFitterProbe",
     "TwoDTiltedGaussianFitterProbe",

--- a/semantiva_imaging/probes/probes.py
+++ b/semantiva_imaging/probes/probes.py
@@ -15,11 +15,11 @@
 from scipy.optimize import curve_fit
 import numpy as np
 from typing import Dict
-from ..processing.processors import ImageProbe
+from ..processing.processors import SingleChannelImageProbe
 from ..data_types import SingleChannelImage
 
 
-class BasicImageProbe(ImageProbe):
+class BasicImageProbe(SingleChannelImageProbe):
     """
     A basic image probe that computes mean, sum, minimum and maximum pixel values.
     """
@@ -42,7 +42,7 @@ class BasicImageProbe(ImageProbe):
         }
 
 
-class TwoDGaussianFitterProbe(ImageProbe):
+class TwoDGaussianFitterProbe(SingleChannelImageProbe):
     """
     A probe that fits a 2D Gaussian function to an image and computes the goodness-of-fit score.
 
@@ -138,7 +138,7 @@ class TwoDGaussianFitterProbe(ImageProbe):
         }
 
 
-class TwoDTiltedGaussianFitterProbe(ImageProbe):
+class TwoDTiltedGaussianFitterProbe(SingleChannelImageProbe):
     """
     A probe that fits a 2D Gaussian function to an image.
     Fitted parameters:

--- a/semantiva_imaging/processing/operations.py
+++ b/semantiva_imaging/processing/operations.py
@@ -18,12 +18,12 @@ from ..data_types import (
     SingleChannelImageStack,
 )
 from ..processing.processors import (
-    ImageOperation,
+    SingleChannelImageOperation,
     SingleChannelImageStackToImageProjector,
 )
 
 
-class ImageSubtraction(ImageOperation):
+class ImageSubtraction(SingleChannelImageOperation):
     """
     Substracts one image from another.
     """
@@ -44,7 +44,7 @@ class ImageSubtraction(ImageOperation):
         return SingleChannelImage(np.subtract(data.data, image_to_subtract.data))
 
 
-class ImageAddition(ImageOperation):
+class ImageAddition(SingleChannelImageOperation):
     """
     Adds two images together.
     """
@@ -65,7 +65,7 @@ class ImageAddition(ImageOperation):
         return SingleChannelImage(np.add(data.data, image_to_add.data))
 
 
-class ImageCropper(ImageOperation):
+class ImageCropper(SingleChannelImageOperation):
     """
     Crops a rectangular region from the input image.
     """
@@ -133,7 +133,7 @@ class StackToImageMeanProjector(SingleChannelImageStackToImageProjector):
         return SingleChannelImage(np.mean(data.data, axis=0))
 
 
-class ImageNormalizerOperation(ImageOperation):
+class ImageNormalizerOperation(SingleChannelImageOperation):
     """
     Linear normalization of an image data to a specified range.
 

--- a/semantiva_imaging/processing/processors.py
+++ b/semantiva_imaging/processing/processors.py
@@ -16,10 +16,8 @@ from semantiva.data_processors import DataOperation, DataProbe
 from ..data_types import SingleChannelImage, SingleChannelImageStack
 
 
-class ImageOperation(DataOperation):
-    """
-    A DataOperation for :class:`SingleChannelImage` data.
-    """
+class SingleChannelImageOperation(DataOperation):
+    """A ``DataOperation`` specialized for :class:`SingleChannelImage` data."""
 
     @classmethod
     def input_data_type(cls):
@@ -94,10 +92,8 @@ class SingleChannelImageStackToImageProjector(DataOperation):
         return SingleChannelImage
 
 
-class ImageProbe(DataProbe):
-    """
-    A DataProbe for :class:`SingleChannelImage` data.
-    """
+class SingleChannelImageProbe(DataProbe):
+    """A ``DataProbe`` for :class:`SingleChannelImage` data."""
 
     @classmethod
     def input_data_type(cls) -> type[SingleChannelImage]:

--- a/tests/test_image_feature_extraction_and_fit_workflows_in_pipelines.py
+++ b/tests/test_image_feature_extraction_and_fit_workflows_in_pipelines.py
@@ -18,7 +18,7 @@ from semantiva.context_processors.context_processors import ModelFittingContextP
 from semantiva.payload_operations.pipeline import Pipeline
 from semantiva_imaging.data_types import SingleChannelImageStack
 
-from semantiva_imaging.probes import TwoDGaussianFitterProbe, ImageProbe
+from semantiva_imaging.probes import TwoDGaussianFitterProbe, SingleChannelImageProbe
 from semantiva_imaging.data_io.loaders_savers import (
     TwoDGaussianImageGenerator,
     ParametricImageStackGenerator,
@@ -26,7 +26,7 @@ from semantiva_imaging.data_io.loaders_savers import (
 from semantiva.data_processors.data_slicer_factory import Slicer
 
 
-class TwoDGaussianStdDevProbe(ImageProbe):
+class TwoDGaussianStdDevProbe(SingleChannelImageProbe):
     """A probe to extract the standard deviation of a 2D Gaussian from an image."""
 
     def _process_logic(self, data):


### PR DESCRIPTION
This PR renames the existing `ImageOperation` → `SingleChannelImageOperation` and `ImageProbe` → `SingleChannelImageProbe` across the repository