### PR TITLE
Add UrlLoader for loading images from HTTP(S) URLs and corresponding tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,19 @@ Visit the repositories:
 
 - **I/O and Image Generation**
   - Load and save images in **PNG**, **JPEG**, **TIFF**, and **NPZ** formats
-  - Load images from HTTP(S) URLs via `UrlLoader`, e.g. `UrlLoader(PngImageLoader)`
-    ```python
-    from semantiva_imaging.data_io import PngImageLoader
-    from semantiva_imaging.data_io.url_loader import UrlLoader
+  - Load images from HTTP(S) URLs via `UrlLoader`, e.g. `UrlLoader(PngRGBImageLoader)`
+```python
+from semantiva_imaging.data_io import PngRGBImageLoader
+from semantiva_imaging.data_io.url_loader import UrlLoader
 
-    loader = UrlLoader(PngImageLoader)
-    image = loader.get_data("https://example.com/example.png")
-    ```
+loader = UrlLoader(PngRGBImageLoader)
+image = loader.get_data("https://avatars.githubusercontent.com/u/195345127?s=48") # Semantiva Github logo
+```
+  - Load and save **animated GIFs** with `AnimatedGifRGBAImageStackLoader` and `AnimatedGifSinglechannelImageStackSaver`
+  - Generate synthetic images using `SingleChannelImageRandomGenerator` and `TwoDGaussianSingleChannelImageGenerator`
+```
   - Save and load video stacks (`.avi`) and animated **GIFs**
-  - Generate synthetic images using `ImageDataRandomGenerator` and `TwoDGaussianImageGenerator`
+  - Generate synthetic images using `SingleChannelImageRandomGenerator` and `TwoDGaussianSingleChannelImageGenerator`
 
 - **Visualization (Jupyter Notebook Compatible)**  
   - **Interactive Cross-Section Viewer** (`ImageCrossSectionInteractiveViewer`) - Explore cross-sections of 2D images dynamically  
@@ -84,7 +87,7 @@ from semantiva.payload_operations.pipeline import Pipeline
 from semantiva.data_processors.data_slicer_factory import Slicer
 
 from semantiva_imaging.data_io.loaders_savers import (
-    TwoDGaussianImageGenerator,
+    TwoDGaussianSingleChannelImageGenerator,
     ParametricImageStackGenerator,
 )
 
@@ -104,7 +107,7 @@ generator = ParametricImageStackGenerator(
     param_ranges={
         "t": (-1, 2)
     },  # 't' will sweep from -1 to +2, controlling the parametric expressions
-    image_generator=TwoDGaussianImageGenerator(),
+    image_generator=TwoDGaussianSingleChannelImageGenerator(),
     image_generator_params={"image_size": (128, 128)},  # Image resolution
 )
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ Visit the repositories:
 
 - **I/O and Image Generation**
   - Load and save images in **PNG**, **JPEG**, **TIFF**, and **NPZ** formats
+  - Load images from HTTP(S) URLs via `UrlLoader`, e.g. `UrlLoader(PngImageLoader)`
+    ```python
+    from semantiva_imaging.data_io import PngImageLoader
+    from semantiva_imaging.data_io.url_loader import UrlLoader
+
+    loader = UrlLoader(PngImageLoader)
+    image = loader.get_data("https://example.com/example.png")
+    ```
   - Save and load video stacks (`.avi`) and animated **GIFs**
   - Generate synthetic images using `ImageDataRandomGenerator` and `TwoDGaussianImageGenerator`
 

--- a/docs/data_io_reference.md
+++ b/docs/data_io_reference.md
@@ -2,9 +2,9 @@
 
 The following loaders and savers are available in `semantiva_imaging.data_io.loaders_savers`:
 
-- `NpzSingleChannelImageLoader` / `NpzImageDataSaver`
-- `NpzSingleChannelImageStackDataLoader` / `NpzImageStackDataSaver`
-- `PngImageLoader` / `PngImageSaver`
+- `NpzSingleChannelImageLoader` / `NpzSingleChannelImageDataSaver`
+- `NpzSingleChannelImageStackDataLoader` / `NpzSingleChannelImageStackDataSaver`
+- `PngSingleChannelImageLoader` / `PngSingleChannelImageSaver`
 - `JpgSingleChannelImageLoader` / `JpgSingleChannelImageSaver`
 - `TiffSingleChannelImageLoader` / `TiffSingleChannelImageSaver`
 - `JpgRGBImageLoader` / `JpgRGBImageSaver`
@@ -14,4 +14,4 @@ The following loaders and savers are available in `semantiva_imaging.data_io.loa
 - `SingleChannelImageStackVideoLoader` / `SingleChannelImageStackAVISaver`
 - `RGBImageStackVideoLoader` / `RGBImageStackAVISaver`
 - `AnimatedGifRGBAImageStackLoader` / `AnimatedGifSinglechannelImageStackSaver`
-- Additionally, HTTP/HTTPS sources can be loaded using `UrlLoader`: `UrlLoader(PngImageLoader)`
+- Additionally, HTTP/HTTPS sources can be loaded using `UrlLoader`: `UrlLoader(PngSingleChannelImageLoader)`

--- a/docs/data_io_reference.md
+++ b/docs/data_io_reference.md
@@ -14,3 +14,4 @@ The following loaders and savers are available in `semantiva_imaging.data_io.loa
 - `SingleChannelImageStackVideoLoader` / `SingleChannelImageStackAVISaver`
 - `RGBImageStackVideoLoader` / `RGBImageStackAVISaver`
 - `AnimatedGifRGBAImageStackLoader` / `AnimatedGifSinglechannelImageStackSaver`
+- Additionally, HTTP/HTTPS sources can be loaded using `UrlLoader`: `UrlLoader(PngImageLoader)`

--- a/examples/image_io_roundtrip.py
+++ b/examples/image_io_roundtrip.py
@@ -9,8 +9,8 @@ from semantiva_imaging.data_types import (
 from semantiva_imaging.data_io.loaders_savers import (
     JpgSingleChannelImageSaver,
     JpgSingleChannelImageLoader,
-    PngImageSaver,
-    PngImageLoader,
+    PngSingleChannelImageSaver,
+    PngSingleChannelImageLoader,
     TiffSingleChannelImageSaver,
     TiffSingleChannelImageLoader,
     SingleChannelImageStackAVISaver,
@@ -24,8 +24,8 @@ if __name__ == "__main__":
     JpgSingleChannelImageSaver().send_data(gray, "roundtrip.jpg")
     print(JpgSingleChannelImageLoader().get_data("roundtrip.jpg"))
 
-    PngImageSaver().send_data(gray, "roundtrip.png")
-    print(PngImageLoader().get_data("roundtrip.png"))
+    PngSingleChannelImageSaver().send_data(gray, "roundtrip.png")
+    print(PngSingleChannelImageLoader().get_data("roundtrip.png"))
 
     TiffSingleChannelImageSaver().send_data(gray, "roundtrip.tiff")
     print(TiffSingleChannelImageLoader().get_data("roundtrip.tiff"))

--- a/semantiva_imaging/README.md
+++ b/semantiva_imaging/README.md
@@ -3,7 +3,7 @@
 This README demonstrates how to **generate, manipulate, visualize, and verify 2D Gaussian images** using **Semantiva's image processing framework**.
 
 ## 🚀 Features Covered:
-- **Generate** 2D Gaussian images with `TwoDGaussianImageGenerator`
+- **Generate** 2D Gaussian images with `TwoDGaussianSingleChannelImageGenerator`
 - **Stack images** into `SingleChannelImageStack`
 - **Apply transformations**:
   - Mean projection (`StackToImageMeanProjector`)
@@ -16,7 +16,7 @@ This README demonstrates how to **generate, manipulate, visualize, and verify 2D
 
 ```python
 import matplotlib.pyplot as plt
-from semantiva_imaging.data_io.loaders_savers import TwoDGaussianImageGenerator
+from semantiva_imaging.data_io.loaders_savers import TwoDGaussianSingleChannelImageGenerator
 from semantiva_imaging.data_types import SingleChannelImageStack
 from semantiva_imaging.processing.operations import (
     StackToImageMeanProjector,
@@ -25,7 +25,7 @@ from semantiva_imaging.processing.operations import (
 from semantiva.specializations.image.image_probes import TwoDGaussianFitterProbe
 
 # Step 1: Generate Gaussian Images using the updated interface
-generator = TwoDGaussianImageGenerator()
+generator = TwoDGaussianSingleChannelImageGenerator()
 
 image1 = generator._get_data(center=(512, 512), std_dev=40, amplitude=100, image_size=(1024, 1024))
 image2 = generator._get_data(center=(550, 550), std_dev=40, amplitude=100, image_size=(1024, 1024))

--- a/semantiva_imaging/data_io/__init__.py
+++ b/semantiva_imaging/data_io/__init__.py
@@ -16,9 +16,9 @@ from .url_loader import UrlLoader
 from .loaders_savers import (
     # Single channel image loaders/savers
     NpzSingleChannelImageLoader,
-    NpzImageDataSaver,
-    PngImageLoader,
-    PngImageSaver,
+    NpzSingleChannelImageDataSaver,
+    PngSingleChannelImageLoader,
+    PngSingleChannelImageSaver,
     JpgSingleChannelImageLoader,
     JpgSingleChannelImageSaver,
     TiffSingleChannelImageLoader,
@@ -37,8 +37,8 @@ from .loaders_savers import (
     TiffRGBAImageSaver,
     # Single channel image stack loaders/savers
     NpzSingleChannelImageStackDataLoader,
-    NpzImageStackDataSaver,
-    PNGImageStackSaver,
+    NpzSingleChannelImageStackDataSaver,
+    PNGSingleChannelImageStackSaver,
     SingleChannelImageStackVideoLoader,
     SingleChannelImageStackAVISaver,
     AnimatedGifSingleChannelImageStackLoader,
@@ -57,9 +57,9 @@ __all__ = [
     "UrlLoader",
     # Single channel image loaders/savers
     "NpzSingleChannelImageLoader",
-    "NpzImageDataSaver",
-    "PngImageLoader",
-    "PngImageSaver",
+    "NpzSingleChannelImageDataSaver",
+    "PngSingleChannelImageLoader",
+    "PngSingleChannelImageSaver",
     "JpgSingleChannelImageLoader",
     "JpgSingleChannelImageSaver",
     "TiffSingleChannelImageLoader",
@@ -78,8 +78,8 @@ __all__ = [
     "TiffRGBAImageSaver",
     # Single channel image stack loaders/savers
     "NpzSingleChannelImageStackDataLoader",
-    "NpzImageStackDataSaver",
-    "PNGImageStackSaver",
+    "NpzSingleChannelImageStackDataSaver",
+    "PNGSingleChannelImageStackSaver",
     "SingleChannelImageStackVideoLoader",
     "SingleChannelImageStackAVISaver",
     "AnimatedGifSingleChannelImageStackLoader",

--- a/semantiva_imaging/data_io/__init__.py
+++ b/semantiva_imaging/data_io/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .url_loader import UrlLoader
 from .loaders_savers import (
     # Single channel image loaders/savers
     NpzSingleChannelImageLoader,
@@ -53,6 +54,7 @@ from .loaders_savers import (
 )
 
 __all__ = [
+    "UrlLoader",
     # Single channel image loaders/savers
     "NpzSingleChannelImageLoader",
     "NpzImageDataSaver",

--- a/semantiva_imaging/data_io/loaders_savers.py
+++ b/semantiva_imaging/data_io/loaders_savers.py
@@ -97,7 +97,7 @@ class NpzSingleChannelImageLoader(SingleChannelImageDataSource):
             raise ValueError(f"Error loading image data from {path}: {e}") from e
 
 
-class NpzImageDataSaver(SingleChannelImageDataSink):
+class NpzSingleChannelImageDataSaver(SingleChannelImageDataSink):
     """Save a ``SingleChannelImage`` to an ``.npz`` file."""
 
     def _send_data(self, data: SingleChannelImage, path: str) -> None:
@@ -174,7 +174,7 @@ class NpzSingleChannelImageStackDataLoader(SingleChannelImageStackSource):
             raise ValueError(f"Error loading image stack data from {path}: {e}") from e
 
 
-class NpzImageStackDataSaver(SingleChannelImageStackSink):
+class NpzSingleChannelImageStackDataSaver(SingleChannelImageStackSink):
     """Save a ``SingleChannelImageStack`` to an ``.npz`` file."""
 
     def _send_data(self, data: SingleChannelImageStack, path: str) -> None:
@@ -201,7 +201,7 @@ class NpzImageStackDataSaver(SingleChannelImageStackSink):
             raise IOError(f"Error saving SingleChannelImageStack to {path}: {e}") from e
 
 
-class PngImageLoader(SingleChannelImageDataSource):
+class PngSingleChannelImageLoader(SingleChannelImageDataSource):
     """
     Concrete implementation of ImageDataTypeSource for loading image data from PNG files.
 
@@ -236,7 +236,7 @@ class PngImageLoader(SingleChannelImageDataSource):
             raise ValueError(f"Error loading PNG image from {path}: {e}") from e
 
 
-class PngImageSaver(SingleChannelImageDataSink):
+class PngSingleChannelImageSaver(SingleChannelImageDataSink):
     """
     Concrete implementation of ImageDataTypeSink for saving image data to PNG files.
 
@@ -444,7 +444,7 @@ class PngRGBAImageSaver(RGBAImageDataSink):
             raise IOError(f"Error saving PNG RGBA image to {path}: {e}") from e
 
 
-class PNGImageStackSaver(SingleChannelImageStackSink):
+class PNGSingleChannelImageStackSaver(SingleChannelImageStackSink):
     """
     Concrete implementation of ImageDataSink for saving multi-frame image data (``SingleChannelImageStack``)
     as sequentially numbered PNG files.
@@ -760,7 +760,7 @@ class AnimatedGifRGBImageStackSaver(RGBImageStackSink):
             raise IOError(f"Error saving GIF to {path}: {e}") from e
 
 
-class ImageDataRandomGenerator(SingleChannelImageDataSource):
+class SingleChannelImageRandomGenerator(SingleChannelImageDataSource):
     """
     A random generator for creating ``SingleChannelImage`` objects with random data.
     """
@@ -788,7 +788,7 @@ class ImageDataRandomGenerator(SingleChannelImageDataSource):
         return SingleChannelImage(np.random.rand(*shape))
 
 
-class TwoDGaussianImageGenerator(SingleChannelImageDataSource):
+class TwoDGaussianSingleChannelImageGenerator(SingleChannelImageDataSource):
     """Generates an image with a 2D Gaussian signal with optional rotation."""
 
     @classmethod

--- a/semantiva_imaging/data_io/url_loader.py
+++ b/semantiva_imaging/data_io/url_loader.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Semantiva authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Utilities for generating HTTP/HTTPS loaders."""
 
 from __future__ import annotations

--- a/semantiva_imaging/data_io/url_loader.py
+++ b/semantiva_imaging/data_io/url_loader.py
@@ -1,0 +1,68 @@
+"""Utilities for generating HTTP/HTTPS loaders."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Type
+from urllib.parse import urlparse
+from urllib.request import urlopen
+
+from semantiva.data_io import DataSource
+
+
+def UrlLoader(
+    loader_cls: Type[DataSource],
+    *,
+    timeout: float = 10.0,
+    max_bytes: int = 10 * 1024 * 1024,
+) -> Type[DataSource]:
+    """Factory to create a URL-based loader from a file-based loader class.
+
+    Parameters
+    ----------
+    loader_cls:
+        Existing loader class expecting a file path.
+    timeout:
+        Timeout for HTTP requests in seconds.
+    max_bytes:
+        Maximum number of bytes to download.
+
+    Returns
+    -------
+    Type[DataSource]
+        A new loader class accepting ``url`` instead of ``path``.
+    """
+
+    if not issubclass(loader_cls, DataSource):
+        raise TypeError("loader_cls must be a DataSource")
+
+    def _get_data(cls, url: str, **kwargs):
+        parsed = urlparse(url)
+        if parsed.scheme not in {"http", "https"}:
+            raise ValueError(f"Unsupported URL scheme: {parsed.scheme}")
+
+        with urlopen(url, timeout=timeout) as resp:
+            data = resp.read(max_bytes + 1)
+            if len(data) > max_bytes:
+                raise ValueError("Download exceeds maximum allowed size")
+            with tempfile.NamedTemporaryFile(delete=False) as tmp:
+                tmp.write(data)
+                temp_path = tmp.name
+        try:
+            return loader_cls._get_data(temp_path, **kwargs)
+        finally:
+            try:
+                os.remove(temp_path)
+            except OSError:
+                pass
+
+    attrs = {
+        "_timeout": timeout,
+        "_max_bytes": max_bytes,
+        "_delegate_cls": loader_cls,
+        "_get_data": classmethod(_get_data),
+        "__doc__": f"URL-based loader wrapping {loader_cls.__name__}.",
+    }
+
+    return type(f"Url{loader_cls.__name__}", (loader_cls,), attrs)

--- a/tests/data_io/test_image_and_video_io.py
+++ b/tests/data_io/test_image_and_video_io.py
@@ -47,8 +47,8 @@ from semantiva_imaging.data_io.loaders_savers import (
     JpgSingleChannelImageSaver,
     TiffSingleChannelImageLoader,
     TiffSingleChannelImageSaver,
-    PngImageLoader,
-    PngImageSaver,
+    PngSingleChannelImageLoader,
+    PngSingleChannelImageSaver,
     JpgRGBImageLoader,
     JpgRGBImageSaver,
     PngRGBImageLoader,
@@ -59,7 +59,7 @@ from semantiva_imaging.data_io.loaders_savers import (
     PngRGBAImageSaver,
     TiffRGBAImageLoader,
     TiffRGBAImageSaver,
-    PNGImageStackSaver,
+    PNGSingleChannelImageStackSaver,
     SingleChannelImageStackVideoLoader,
     SingleChannelImageStackAVISaver,
     RGBImageStackVideoLoader,
@@ -423,7 +423,11 @@ def test_comprehensive_format_support(tmp_dir):
 
     single_formats = [
         ("test.jpg", JpgSingleChannelImageSaver(), JpgSingleChannelImageLoader()),
-        ("test.png", PngImageSaver(), PngImageLoader()),  # Using existing PNG classes
+        (
+            "test.png",
+            PngSingleChannelImageSaver(),
+            PngSingleChannelImageLoader(),
+        ),  # Using existing PNG classes
         ("test.tiff", TiffSingleChannelImageSaver(), TiffSingleChannelImageLoader()),
     ]
 
@@ -470,9 +474,9 @@ def test_comprehensive_format_support(tmp_dir):
         np.random.randint(0, 255, (3, 4, 4), dtype=np.uint8)
     )
 
-    # Test PNGImageStackSaver (saves multiple PNG files)
+    # Test PNGSingleChannelImageStackSaver (saves multiple PNG files)
     base_path = os.path.join(tmp_dir, "png_stack")
-    PNGImageStackSaver().send_data(gray_stack, base_path)
+    PNGSingleChannelImageStackSaver().send_data(gray_stack, base_path)
 
     # Verify the files were created
     for i in range(3):
@@ -480,7 +484,7 @@ def test_comprehensive_format_support(tmp_dir):
         assert os.path.exists(png_file), f"PNG stack file {png_file} was not created"
 
         # Verify content by loading with PIL
-        loaded_img = PngImageLoader().get_data(png_file)
+        loaded_img = PngSingleChannelImageLoader().get_data(png_file)
         loaded_array = np.array(loaded_img.data)
         np.testing.assert_array_equal(loaded_array, gray_stack.data[i])
 
@@ -572,8 +576,8 @@ def test_missing_combinations_intentionally_absent():
 
 
 def test_png_image_stack_saver_basic(tmp_dir):
-    """Test basic PNGImageStackSaver functionality."""
-    from semantiva_imaging.data_io import PNGImageStackSaver
+    """Test basic PNGSingleChannelImageStackSaver functionality."""
+    from semantiva_imaging.data_io import PNGSingleChannelImageStackSaver
 
     # Create a test stack with 3 frames
     stack_data = np.array(
@@ -589,7 +593,7 @@ def test_png_image_stack_saver_basic(tmp_dir):
     base_path = os.path.join(tmp_dir, "test_stack")
 
     # Save the stack
-    saver = PNGImageStackSaver()
+    saver = PNGSingleChannelImageStackSaver()
     saver.send_data(gray_stack, base_path)
 
     # Check that the expected files were created
@@ -605,7 +609,7 @@ def test_png_image_stack_saver_basic(tmp_dir):
 
     # Load the files back and verify content
     for i, file_path in enumerate(expected_files):
-        loaded_img = PngImageLoader().get_data(file_path)
+        loaded_img = PngSingleChannelImageLoader().get_data(file_path)
         loaded_array = loaded_img.data
 
         # Compare with original frame
@@ -617,15 +621,15 @@ def test_png_image_stack_saver_basic(tmp_dir):
 
 
 def test_png_image_stack_saver_empty_stack(tmp_dir):
-    """Test PNGImageStackSaver with empty stack."""
-    from semantiva_imaging.data_io import PNGImageStackSaver
+    """Test PNGSingleChannelImageStackSaver with empty stack."""
+    from semantiva_imaging.data_io import PNGSingleChannelImageStackSaver
 
     # Create an empty stack
     empty_data = np.empty((0, 10, 10), dtype=np.uint8)
     empty_stack = SingleChannelImageStack(empty_data)
     base_path = os.path.join(tmp_dir, "empty_stack")
 
-    saver = PNGImageStackSaver()
+    saver = PNGSingleChannelImageStackSaver()
     saver.send_data(empty_stack, base_path)
 
     # No files should be created for empty stack
@@ -639,15 +643,15 @@ def test_png_image_stack_saver_empty_stack(tmp_dir):
 
 
 def test_png_image_stack_saver_single_frame(tmp_dir):
-    """Test PNGImageStackSaver with single frame."""
-    from semantiva_imaging.data_io import PNGImageStackSaver
+    """Test PNGSingleChannelImageStackSaver with single frame."""
+    from semantiva_imaging.data_io import PNGSingleChannelImageStackSaver
 
     # Create a single frame stack
     single_frame = np.random.randint(0, 255, (1, 16, 16), dtype=np.uint8)
     single_stack = SingleChannelImageStack(single_frame)
     base_path = os.path.join(tmp_dir, "single_frame")
 
-    saver = PNGImageStackSaver()
+    saver = PNGSingleChannelImageStackSaver()
     saver.send_data(single_stack, base_path)
 
     # Only one file should be created
@@ -658,15 +662,15 @@ def test_png_image_stack_saver_single_frame(tmp_dir):
     assert not os.path.exists(unexpected_file), "Unexpected second file was created"
 
     # Verify content
-    loaded_img = PngImageLoader().get_data(expected_file)
+    loaded_img = PngSingleChannelImageLoader().get_data(expected_file)
 
     loaded_array = np.array(loaded_img.data)
     np.testing.assert_array_equal(loaded_array, single_frame[0])
 
 
 def test_png_image_stack_saver_large_stack(tmp_dir):
-    """Test PNGImageStackSaver with larger stack (10 frames)."""
-    from semantiva_imaging.data_io import PNGImageStackSaver
+    """Test PNGSingleChannelImageStackSaver with larger stack (10 frames)."""
+    from semantiva_imaging.data_io import PNGSingleChannelImageStackSaver
 
     # Create a 10-frame stack
     num_frames = 10
@@ -674,7 +678,7 @@ def test_png_image_stack_saver_large_stack(tmp_dir):
     large_stack = SingleChannelImageStack(stack_data)
     base_path = os.path.join(tmp_dir, "large_stack")
 
-    saver = PNGImageStackSaver()
+    saver = PNGSingleChannelImageStackSaver()
     saver.send_data(large_stack, base_path)
 
     # Check all files were created with correct numbering
@@ -683,7 +687,7 @@ def test_png_image_stack_saver_large_stack(tmp_dir):
         assert os.path.exists(expected_file), f"Frame {i} file was not created"
 
         # Verify content
-        loaded_img = PngImageLoader().get_data(expected_file)
+        loaded_img = PngSingleChannelImageLoader().get_data(expected_file)
         loaded_array = loaded_img.data
         np.testing.assert_array_equal(
             loaded_array, stack_data[i], err_msg=f"Frame {i} content mismatch"
@@ -691,8 +695,8 @@ def test_png_image_stack_saver_large_stack(tmp_dir):
 
 
 def test_png_image_stack_saver_invalid_input(tmp_dir):
-    """Test PNGImageStackSaver with invalid input."""
-    from semantiva_imaging.data_io import PNGImageStackSaver
+    """Test PNGSingleChannelImageStackSaver with invalid input."""
+    from semantiva_imaging.data_io import PNGSingleChannelImageStackSaver
     from semantiva_imaging.data_types import RGBImage
 
     # Try to save an RGB image instead of SingleChannelImageStack
@@ -700,15 +704,15 @@ def test_png_image_stack_saver_invalid_input(tmp_dir):
     rgb_img = RGBImage(rgb_data)
     base_path = os.path.join(tmp_dir, "invalid_input")
 
-    saver = PNGImageStackSaver()
+    saver = PNGSingleChannelImageStackSaver()
 
     with pytest.raises(ValueError, match="not an instance of SingleChannelImageStack"):
         saver.send_data(rgb_img, base_path)
 
 
 def test_png_image_stack_saver_different_data_types(tmp_dir):
-    """Test PNGImageStackSaver with different data types."""
-    from semantiva_imaging.data_io import PNGImageStackSaver
+    """Test PNGSingleChannelImageStackSaver with different data types."""
+    from semantiva_imaging.data_io import PNGSingleChannelImageStackSaver
 
     # Test with float32 data (should be converted to uint8)
     float_data = (
@@ -722,7 +726,7 @@ def test_png_image_stack_saver_different_data_types(tmp_dir):
     float_stack = SingleChannelImageStack(float_data)
     base_path = os.path.join(tmp_dir, "float_stack")
 
-    saver = PNGImageStackSaver()
+    saver = PNGSingleChannelImageStackSaver()
     saver.send_data(float_stack, base_path)
 
     # Check files were created
@@ -731,21 +735,21 @@ def test_png_image_stack_saver_different_data_types(tmp_dir):
         assert os.path.exists(expected_file), f"Float frame {i} file was not created"
 
         # Verify that data was properly converted to uint8
-        loaded_img = PngImageLoader().get_data(expected_file)
+        loaded_img = PngSingleChannelImageLoader().get_data(expected_file)
         loaded_array = loaded_img.data
         expected_array = float_data[i].astype(np.uint8)
         np.testing.assert_array_equal(loaded_array, expected_array)
 
 
 def test_png_image_stack_saver_edge_case_paths(tmp_dir):
-    """Test PNGImageStackSaver with various path formats."""
-    from semantiva_imaging.data_io import PNGImageStackSaver
+    """Test PNGSingleChannelImageStackSaver with various path formats."""
+    from semantiva_imaging.data_io import PNGSingleChannelImageStackSaver
 
     # Create test data
     test_data = np.random.randint(0, 255, (2, 4, 4), dtype=np.uint8)
     test_stack = SingleChannelImageStack(test_data)
 
-    saver = PNGImageStackSaver()
+    saver = PNGSingleChannelImageStackSaver()
 
     # Test with path containing dots
     base_path_with_dots = os.path.join(tmp_dir, "test.with.dots")

--- a/tests/test_image_algorithm.py
+++ b/tests/test_image_algorithm.py
@@ -23,7 +23,7 @@ from semantiva_imaging.processing.operations import (
     SingleChannelImageStackSideBySideProjector,
 )
 from semantiva_imaging.data_io.loaders_savers import (
-    ImageDataRandomGenerator,
+    SingleChannelImageRandomGenerator,
     SingleChannelImageStackRandomGenerator,
 )
 from semantiva_imaging.data_types import (
@@ -35,7 +35,7 @@ from semantiva_imaging.data_types import (
 @pytest.fixture
 def dummy_image_data():
     """Fixture for generating dummy SingleChannelImage data."""
-    generator = ImageDataRandomGenerator()
+    generator = SingleChannelImageRandomGenerator()
     return generator.get_data((256, 256))
 
 

--- a/tests/test_image_feature_extraction_and_fit_workflows_in_pipelines.py
+++ b/tests/test_image_feature_extraction_and_fit_workflows_in_pipelines.py
@@ -20,7 +20,7 @@ from semantiva_imaging.data_types import SingleChannelImageStack
 
 from semantiva_imaging.probes import TwoDGaussianFitterProbe, SingleChannelImageProbe
 from semantiva_imaging.data_io.loaders_savers import (
-    TwoDGaussianImageGenerator,
+    TwoDGaussianSingleChannelImageGenerator,
     ParametricImageStackGenerator,
 )
 from semantiva.data_processors.data_slicer_factory import Slicer
@@ -47,7 +47,7 @@ def image_stack():
             "amplitude": "100",
         },
         param_ranges={"t": (-1, 2)},
-        image_generator=TwoDGaussianImageGenerator(),
+        image_generator=TwoDGaussianSingleChannelImageGenerator(),
         image_generator_params={
             "image_size": (128, 128)
         },  # Use a much smaller image size

--- a/tests/test_image_io.py
+++ b/tests/test_image_io.py
@@ -20,14 +20,14 @@ from semantiva_imaging.data_types import (
     SingleChannelImageStack,
 )
 from semantiva_imaging.data_io.loaders_savers import (
-    ImageDataRandomGenerator,
+    SingleChannelImageRandomGenerator,
     SingleChannelImageStackRandomGenerator,
     NpzSingleChannelImageLoader,
     NpzSingleChannelImageStackDataLoader,
-    PngImageLoader,
-    NpzImageDataSaver,
-    NpzImageStackDataSaver,
-    PngImageSaver,
+    PngSingleChannelImageLoader,
+    NpzSingleChannelImageDataSaver,
+    NpzSingleChannelImageStackDataSaver,
+    PngSingleChannelImageSaver,
 )
 
 
@@ -36,7 +36,7 @@ def sample_image_data():
     """
     Fixture to provide a sample SingleChannelImage using the dummy generator.
     """
-    generator = ImageDataRandomGenerator()
+    generator = SingleChannelImageRandomGenerator()
     return generator.get_data((256, 256))
 
 
@@ -63,7 +63,7 @@ def test_npz_image_loader(sample_image_data, tmp_test_dir):
     """
     # Save the generated image to a .npz file
     file_path = os.path.join(tmp_test_dir, "image_data.npz")
-    saver = NpzImageDataSaver()
+    saver = NpzSingleChannelImageDataSaver()
     saver.send_data(sample_image_data, file_path)
 
     # Load the image back and verify
@@ -79,7 +79,7 @@ def test_npz_stack_loader(sample_stack_data, tmp_test_dir):
     """
     # Save the generated stack to a .npz file
     file_path = os.path.join(tmp_test_dir, "stack_data.npz")
-    saver = NpzImageStackDataSaver()
+    saver = NpzSingleChannelImageStackDataSaver()
     saver.send_data(sample_stack_data, file_path)
 
     # Load the stack back and verify
@@ -95,11 +95,11 @@ def test_png_image_loader(sample_image_data, tmp_test_dir):
     """
     # Save the generated image to a .png file
     file_path = os.path.join(tmp_test_dir, "image_data.png")
-    saver = PngImageSaver()
+    saver = PngSingleChannelImageSaver()
     saver.send_data(sample_image_data, file_path)
 
     # Load the image back and verify
-    loader = PngImageLoader()
+    loader = PngSingleChannelImageLoader()
     image_data = loader.get_data(file_path)
     assert isinstance(image_data, SingleChannelImage)
     assert image_data.data.shape == sample_image_data.data.shape

--- a/tests/test_image_pipeline.py
+++ b/tests/test_image_pipeline.py
@@ -21,7 +21,7 @@ from semantiva_imaging.data_types import (
 )
 from semantiva.payload_operations import Pipeline
 from semantiva_imaging.data_io.loaders_savers import (
-    ImageDataRandomGenerator,
+    SingleChannelImageRandomGenerator,
     SingleChannelImageStackRandomGenerator,
 )
 from semantiva.tools import PipelineInspector
@@ -41,7 +41,7 @@ def random_image1():
     """
     Pytest fixture for providing a random 2D SingleChannelImage instance using the dummy generator.
     """
-    generator = ImageDataRandomGenerator()
+    generator = SingleChannelImageRandomGenerator()
     return generator.get_data((256, 256))
 
 
@@ -50,7 +50,7 @@ def random_image2():
     """
     Pytest fixture for providing another random 2D SingleChannelImage instance using the dummy generator.
     """
-    generator = ImageDataRandomGenerator()
+    generator = SingleChannelImageRandomGenerator()
     return generator.get_data((256, 256))
 
 

--- a/tests/test_image_pipeline_slicing.py
+++ b/tests/test_image_pipeline_slicing.py
@@ -18,7 +18,7 @@ from semantiva.context_processors.context_types import (
     ContextCollectionType,
 )
 from semantiva_imaging.data_io.loaders_savers import (
-    ImageDataRandomGenerator,
+    SingleChannelImageRandomGenerator,
     SingleChannelImageStackRandomGenerator,
 )
 from semantiva_imaging.processing.operations import (
@@ -43,7 +43,7 @@ def random_image():
     """
     Pytest fixture providing a random 2D SingleChannelImage instance.
     """
-    generator = ImageDataRandomGenerator()
+    generator = SingleChannelImageRandomGenerator()
     return generator.get_data((256, 256))
 
 
@@ -52,7 +52,7 @@ def another_random_image():
     """
     Pytest fixture providing another random 2D SingleChannelImage instance.
     """
-    generator = ImageDataRandomGenerator()
+    generator = SingleChannelImageRandomGenerator()
     return generator.get_data((256, 256))
 
 

--- a/tests/test_image_pipeline_yaml.py
+++ b/tests/test_image_pipeline_yaml.py
@@ -19,7 +19,7 @@ from semantiva_imaging.data_types import SingleChannelImage
 from semantiva.configurations.load_pipeline_from_yaml import load_pipeline_from_yaml
 from semantiva.context_processors.context_types import ContextType
 from semantiva_imaging.data_io.loaders_savers import (
-    ImageDataRandomGenerator,
+    SingleChannelImageRandomGenerator,
 )
 
 
@@ -34,7 +34,7 @@ def random_image1():
     """
     Pytest fixture for providing a random 2D SingleChannelImage instance using the dummy generator.
     """
-    generator = ImageDataRandomGenerator()
+    generator = SingleChannelImageRandomGenerator()
     return generator.get_data((256, 256))
 
 

--- a/tests/test_image_probe.py
+++ b/tests/test_image_probe.py
@@ -19,7 +19,7 @@ from semantiva_imaging.probes import (
     TwoDGaussianFitterProbe,
 )
 from semantiva_imaging.data_io.loaders_savers import (
-    TwoDGaussianImageGenerator,
+    TwoDGaussianSingleChannelImageGenerator,
 )
 
 
@@ -35,7 +35,7 @@ def gaussian_fitter_probe():
 
 @pytest.fixture
 def gaussian_image_generator():
-    return TwoDGaussianImageGenerator()
+    return TwoDGaussianSingleChannelImageGenerator()
 
 
 def test_basic_image_probe(basic_probe, gaussian_image_generator):

--- a/tests/test_url_loader.py
+++ b/tests/test_url_loader.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Semantiva authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import threading
 from http.server import ThreadingHTTPServer, SimpleHTTPRequestHandler
@@ -6,7 +20,10 @@ import numpy as np
 import pytest
 
 from semantiva_imaging.data_types import SingleChannelImage
-from semantiva_imaging.data_io import PngImageSaver, PngImageLoader
+from semantiva_imaging.data_io import (
+    PngSingleChannelImageSaver,
+    PngSingleChannelImageLoader,
+)
 from semantiva_imaging.data_io.url_loader import UrlLoader
 
 
@@ -14,7 +31,7 @@ from semantiva_imaging.data_io.url_loader import UrlLoader
 def http_image_server(tmp_path):
     img = SingleChannelImage(np.random.randint(0, 255, (5, 5), dtype=np.uint8))
     fname = tmp_path / "img.png"
-    PngImageSaver().send_data(img, str(fname))
+    PngSingleChannelImageSaver().send_data(img, str(fname))
 
     cwd = os.getcwd()
     os.chdir(tmp_path)
@@ -32,19 +49,19 @@ def http_image_server(tmp_path):
 
 def test_url_loader_success(http_image_server):
     url, original = http_image_server
-    Loader = UrlLoader(PngImageLoader)
+    Loader = UrlLoader(PngSingleChannelImageLoader)
     loaded = Loader.get_data(url)
     assert np.array_equal(loaded.data, original.data)
 
 
 def test_url_loader_invalid_scheme():
-    Loader = UrlLoader(PngImageLoader)
+    Loader = UrlLoader(PngSingleChannelImageLoader)
     with pytest.raises(ValueError):
         Loader.get_data("ftp://example.com/img.png")
 
 
 def test_url_loader_size_limit(http_image_server):
     url, _ = http_image_server
-    Loader = UrlLoader(PngImageLoader, max_bytes=10)
+    Loader = UrlLoader(PngSingleChannelImageLoader, max_bytes=10)
     with pytest.raises(ValueError):
         Loader.get_data(url)

--- a/tests/test_url_loader.py
+++ b/tests/test_url_loader.py
@@ -1,0 +1,50 @@
+import os
+import threading
+from http.server import ThreadingHTTPServer, SimpleHTTPRequestHandler
+
+import numpy as np
+import pytest
+
+from semantiva_imaging.data_types import SingleChannelImage
+from semantiva_imaging.data_io import PngImageSaver, PngImageLoader
+from semantiva_imaging.data_io.url_loader import UrlLoader
+
+
+@pytest.fixture
+def http_image_server(tmp_path):
+    img = SingleChannelImage(np.random.randint(0, 255, (5, 5), dtype=np.uint8))
+    fname = tmp_path / "img.png"
+    PngImageSaver().send_data(img, str(fname))
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    server = ThreadingHTTPServer(("localhost", 0), SimpleHTTPRequestHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    port = server.server_address[1]
+    yield f"http://localhost:{port}/img.png", img
+
+    server.shutdown()
+    thread.join()
+    os.chdir(cwd)
+
+
+def test_url_loader_success(http_image_server):
+    url, original = http_image_server
+    Loader = UrlLoader(PngImageLoader)
+    loaded = Loader.get_data(url)
+    assert np.array_equal(loaded.data, original.data)
+
+
+def test_url_loader_invalid_scheme():
+    Loader = UrlLoader(PngImageLoader)
+    with pytest.raises(ValueError):
+        Loader.get_data("ftp://example.com/img.png")
+
+
+def test_url_loader_size_limit(http_image_server):
+    url, _ = http_image_server
+    Loader = UrlLoader(PngImageLoader, max_bytes=10)
+    with pytest.raises(ValueError):
+        Loader.get_data(url)


### PR DESCRIPTION
Any image loader can now be adapted for fetching images using http and https protocols.

Piggyback (separate commit): Rename SingleImage Loaders and Savers for consistency and clarity. Drop usage of ambiguous "Image" loaders in favor of explicit "SingleChannelImage"-named components.