### PR TITLE
feat: upgrade to upcoming semantiva 0.5.0 and update API usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Guidelines for Semantiva Imaging
 
-This repository houses **Semantiva Imaging**, the imaging specialization of the Semantiva framework. It extends the core dual-channel pipeline with domain-specific data types, operations, I/O utilities and visualization helpers for working with images and image stacks.
+This repository houses **Semantiva Imaging**, the imaging extension of the Semantiva framework. It extends the core dual-channel pipeline with domain-specific data types, operations, I/O utilities and visualization helpers for working with images and image stacks.
 
 ## Repository Layout
 
@@ -15,7 +15,7 @@ This repository houses **Semantiva Imaging**, the imaging specialization of the 
 * **tests/** - Pytest suite covering data types, I/O, operations, visualization, and pipelines.
 * **docs/** - additional documentation assets used in the README.
 
-The package is registered with Semantiva through `ImagingSpecialization`, enabling dynamic loading of its processors via the framework's `ComponentLoader`.
+The package is registered with Semantiva through `ImagingExtension`, enabling dynamic loading of its processors via the framework's `ClassRegistry`.
 
 ## Contribution Workflow
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ pip install semantiva semantiva-imaging
 
 ## Getting Started: A Parameterized Feature Extract-and-Fit Workflow
 
-This is an advanced example demonstrating how Semantiva with Imaging specialization can generate images **based on metadata parameters**, extract features, and fit a simple model—all within a single pipeline. Notice how **context metadata** flows alongside **data**, allowing each operation to dynamically pull parameters from the context.
+This is an advanced example demonstrating how Semantiva with Imaging extension can generate images **based on metadata parameters**, extract features, and fit a simple model—all within a single pipeline. Notice how **context metadata** flows alongside **data**, allowing each operation to dynamically pull parameters from the context.
 
 The parametrized generator bellow creates a stack of images with a time-varying 2D Gaussian signal. The signal's position, standard deviation, and orientation change over time. We then extract the Gaussian parameters from each frame and fit linear models to the standard deviation and orientation angle over time.
 
@@ -83,7 +83,8 @@ from semantiva_imaging.probes import (
 from semantiva_imaging.data_types.data_types import SingleChannelImageStack
 from semantiva.workflows.fitting_model import PolynomialFittingModel
 from semantiva.context_processors.context_processors import ModelFittingContextProcessor
-from semantiva.payload_operations.pipeline import Pipeline
+from semantiva.pipeline import Pipeline
+from semantiva.pipeline.payload import Payload
 from semantiva.data_processors.data_slicer_factory import Slicer
 
 from semantiva_imaging.data_io.loaders_savers import (
@@ -158,15 +159,17 @@ node_configurations = [
 # --- 3) Create and Run the Pipeline ---
 pipeline = Pipeline(node_configurations)
 
-from semantiva.tools import PipelineInspector
+from semantiva.inspection import build_pipeline_inspection, summary_report
 print("Pipeline inspection:")
-print(PipelineInspector.inspect_pipeline(pipeline))
+inspection = build_pipeline_inspection(node_configurations)
+print(summary_report(inspection))
 for index, node in enumerate(pipeline.nodes, start=1):
     print(f"\nNode {index}")
     print(node.semantic_id())
 # Pass the image stack (data) and the context dictionary (metadata) to the pipeline.
 # Each pipeline step can read/write both data and context, enabling dynamic parameter injection.
-output_data, output_context = pipeline.process(image_stack, context_dict)
+payload_out = pipeline.process(Payload(image_stack, context_dict))
+output_data, output_context = payload_out.data, payload_out.context
 
 # --- 4) Inspect Results ---
 # 'std_dev_coefficients' and 'orientation_coefficients' were computed during pipeline execution.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "semantiva-imaging"
 dynamic = ["version"]
-description = "Image specialization of Semantiva framework."
+description = "Image extension of Semantiva framework."
 license = "Apache-2.0"
 readme = "README.md" 
 requires-python = ">=3.10.12"
@@ -9,7 +9,7 @@ dependencies = [
     "black>=24.10.0",
     "mypy>=1.14.1",
     "numpy>=2.2.1",
-    "semantiva>=0.4.0",
+    "semantiva>=0.5.0",
     "pylint>=3.3.3",
     "pytest>=8.3.4",
     "coverage",
@@ -25,8 +25,8 @@ dependencies = [
 ]
 distribution = true
 
-[project.entry-points.'semantiva.specializations']
-imaging = "semantiva_imaging:ImagingSpecialization"
+[project.entry-points.'semantiva.extensions']
+semantiva_imaging = "semantiva_imaging:ImagingExtension"
 
 [tool.black]
 # Configuration for the black code formatter
@@ -39,7 +39,7 @@ fail-under = 7.5
 
 [tool.mypy]
 exclude = [
-    "^tests/test_string_specialization\\.py$",
+    "^tests/test_string_extension\\.py$",
     "docs/", 
 ]
 ignore_missing_imports = true

--- a/semantiva_imaging/README.md
+++ b/semantiva_imaging/README.md
@@ -22,7 +22,7 @@ from semantiva_imaging.processing.operations import (
     StackToImageMeanProjector,
     SingleChannelImageStackSideBySideProjector,
 )
-from semantiva.specializations.image.image_probes import TwoDGaussianFitterProbe
+from semantiva_imaging.probes import TwoDGaussianFitterProbe
 
 # Step 1: Generate Gaussian Images using the updated interface
 generator = TwoDGaussianSingleChannelImageGenerator()

--- a/semantiva_imaging/__init__.py
+++ b/semantiva_imaging/__init__.py
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Semantiva Imaging specialization package."""
+"""Semantiva Imaging extension package."""
 
-from semantiva.specializations import SemantivaSpecialization
-from semantiva.component_loader import ComponentLoader
+from semantiva.registry import SemantivaExtension
+from semantiva.registry.class_registry import ClassRegistry
 
 
-class ImagingSpecialization(SemantivaSpecialization):
-    """Specialization for image processing."""
+class ImagingExtension(SemantivaExtension):
+    """Extension for image processing."""
 
-    def __init__(self, loader: ComponentLoader | None = None) -> None:
+    def __init__(self, loader: ClassRegistry | None = None) -> None:
         """Store the loader used for registration."""
-        self.loader = loader or ComponentLoader
+        self.loader = loader or ClassRegistry
 
     def register(self) -> None:
         registered_modules = [
@@ -32,4 +32,4 @@ class ImagingSpecialization(SemantivaSpecialization):
             "semantiva_imaging.data_io.loaders_savers",
             "semantiva_imaging.adapters.opencv_library.builders",
         ]
-        ComponentLoader.register_modules(registered_modules)
+        ClassRegistry.register_modules(registered_modules)

--- a/semantiva_imaging/probes/__init__.py
+++ b/semantiva_imaging/probes/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Public probe classes for the imaging specialization."""
+"""Public probe classes for the imaging extension."""
 
 from .probes import (
     SingleChannelImageProbe,

--- a/tests/opencv_library/test_integration_pipeline.py
+++ b/tests/opencv_library/test_integration_pipeline.py
@@ -14,15 +14,16 @@
 
 import numpy as np
 import cv2
-from semantiva.specializations import load_specializations
-from semantiva.payload_operations import Pipeline
+from semantiva.registry.plugin_registry import load_extensions
+from semantiva.pipeline import Pipeline
 from semantiva.context_processors.context_types import ContextType
+from semantiva.pipeline.payload import Payload
 
 from semantiva_imaging.data_types import RGBImage
 
 
 def test_pipeline_smoke():
-    load_specializations("imaging")
+    load_extensions("semantiva_imaging")
     img_arr = np.random.randint(0, 255, (10, 10, 3), dtype=np.uint8)
     img = RGBImage(img_arr)
     pipeline = Pipeline(
@@ -69,6 +70,7 @@ def test_pipeline_smoke():
             },
         ]
     )
-    out, _ = pipeline.process(img, ContextType())
+    payload_out = pipeline.process(Payload(img, ContextType()))
+    out = payload_out.data
     assert out.data.shape == (20, 20)
     assert out.data.mean() >= 0

--- a/tests/pipeline_parametric_gaussian_fit.yaml
+++ b/tests/pipeline_parametric_gaussian_fit.yaml
@@ -1,0 +1,34 @@
+extensions:  ["semantiva_imaging"]
+
+pipeline:
+  nodes:
+    - processor: "sweep:TwoDGaussianSingleChannelImageGenerator:SingleChannelImageStack"
+      parameters:
+        num_steps: 3
+        independent_vars:
+          t: [-1, 2]
+        parametric_expressions:
+          x_0: "50 + 5 * t"
+          y_0: "50 + 5 * t + 5 * t ** 2"
+          "std_dev": "(50 + 20 * t, 20)"
+          amplitude: "100"
+          angle: "60 + 5 * t"
+        static_params:
+          image_size: [128, 128]
+
+    - processor: "slicer:TwoDTiltedGaussianFitterProbe:SingleChannelImageStack"
+      context_keyword: "gaussian_fit_parameters"
+
+    - processor: ModelFittingContextProcessor
+      parameters:
+        fitting_model: "model:PolynomialFittingModel:degree=1"
+        independent_var_key: "t_values"
+        dependent_var_key: ["gaussian_fit_parameters", "std_dev_x"]
+        context_keyword: "std_dev_coefficients"
+
+    - processor: ModelFittingContextProcessor
+      parameters:
+        fitting_model: "model:PolynomialFittingModel:degree=1"
+        independent_var_key: "t_values"
+        dependent_var_key: ["gaussian_fit_parameters", "angle"]
+        context_keyword: "orientation_coefficients"

--- a/tests/test_image_feature_extraction_and_fit_workflows_in_pipelines.py
+++ b/tests/test_image_feature_extraction_and_fit_workflows_in_pipelines.py
@@ -15,7 +15,8 @@
 import pytest
 from semantiva.workflows.fitting_model import PolynomialFittingModel
 from semantiva.context_processors.context_processors import ModelFittingContextProcessor
-from semantiva.payload_operations.pipeline import Pipeline
+from semantiva.pipeline import Pipeline
+from semantiva.pipeline.payload import Payload
 from semantiva_imaging.data_types import SingleChannelImageStack
 
 from semantiva_imaging.probes import TwoDGaussianFitterProbe, SingleChannelImageProbe
@@ -75,7 +76,8 @@ def test_pipeline_single_string_key(image_stack):
     ]
     pipeline = Pipeline(node_configurations)
     context_dict = {"t_values": t_values}
-    output_data, output_context = pipeline.process(image_data, context_dict)
+    payload_out = pipeline.process(Payload(image_data, context_dict))
+    output_context = payload_out.context
     assert "std_dev_coefficients" in output_context.keys()
 
 
@@ -99,5 +101,6 @@ def test_pipeline_tuple_key(image_stack):
     ]
     pipeline = Pipeline(node_configurations)
     context_dict = {"t_values": t_values}
-    output_data, output_context = pipeline.process(image_data, context_dict)
+    payload_out = pipeline.process(Payload(image_data, context_dict))
+    output_context = payload_out.context
     assert "std_dev_coefficients" in output_context.keys()

--- a/tests/test_image_pipeline_slicing.py
+++ b/tests/test_image_pipeline_slicing.py
@@ -27,7 +27,8 @@ from semantiva_imaging.processing.operations import (
     ImageCropper,
     StackToImageMeanProjector,
 )
-from semantiva.payload_operations import Pipeline
+from semantiva.pipeline import Pipeline
+from semantiva.pipeline.payload import Payload
 from semantiva_imaging.data_types import (
     SingleChannelImage,
     SingleChannelImageStack,
@@ -129,7 +130,8 @@ def test_pipeline_slicing_with_single_context(
 
     pipeline = Pipeline(node_configurations)
 
-    output_data, output_context = pipeline.process(random_image_stack, random_context)
+    payload_out = pipeline.process(Payload(random_image_stack, random_context))
+    output_data, output_context = payload_out.data, payload_out.context
     assert len(
         pipeline.get_probe_results()["Node 4/SlicerForBasicImageProbe"][0]
     ) == len(output_data)
@@ -198,9 +200,10 @@ def test_pipeline_slicing_with_context_collection(
     ]
     pipeline = Pipeline(node_configurations)
 
-    output_data, output_context = pipeline.process(
-        random_image_stack, random_context_collection
+    payload_out = pipeline.process(
+        Payload(random_image_stack, random_context_collection)
     )
+    output_data, output_context = payload_out.data, payload_out.context
 
     assert len(
         pipeline.get_probe_results()["Node 4/SlicerForBasicImageProbe"][0]
@@ -237,7 +240,8 @@ def test_pipeline_without_slicing(random_image, another_random_image, random_con
 
     pipeline = Pipeline(node_configurations)
 
-    output_data, output_context = pipeline.process(random_image, random_context)
+    payload_out = pipeline.process(Payload(random_image, random_context))
+    output_data, output_context = payload_out.data, payload_out.context
 
     assert isinstance(
         output_data, SingleChannelImage
@@ -265,4 +269,4 @@ def test_pipeline_invalid_slicing(random_image, random_context):
     pipeline = Pipeline(node_configurations)
 
     with pytest.raises(TypeError):
-        pipeline.process(random_image, random_context)
+        pipeline.process(Payload(random_image, random_context))

--- a/tests/test_image_pipeline_yaml.py
+++ b/tests/test_image_pipeline_yaml.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 import pytest
-from semantiva.payload_operations import Pipeline
-from semantiva.specializations import load_specializations
+from semantiva.pipeline import Pipeline
+from semantiva.registry.plugin_registry import load_extensions
 from semantiva_imaging.data_types import SingleChannelImage
 from semantiva.configurations.load_pipeline_from_yaml import load_pipeline_from_yaml
 from semantiva.context_processors.context_types import ContextType
+from semantiva.pipeline.payload import Payload
 from semantiva_imaging.data_io.loaders_savers import (
     SingleChannelImageRandomGenerator,
 )
@@ -47,12 +48,13 @@ def context_type(random_image1):
 def test_pipeline_yaml(random_image1, yaml_config_path, context_type):
     """Test the pipeline processing using a YAML configuration file."""
 
-    load_specializations("imaging")
+    load_extensions("imaging")
 
     load_pipeline_config = load_pipeline_from_yaml(yaml_config_path)
     pipeline = Pipeline(load_pipeline_config)
 
-    data, context = pipeline.process(random_image1, context_type)
+    payload_out = pipeline.process(Payload(random_image1, context_type))
+    data, context = payload_out.data, payload_out.context
 
     assert "final_info" in context.keys()
     assert "image_to_add" not in context.keys()

--- a/tests/test_nchannel_processor_factory.py
+++ b/tests/test_nchannel_processor_factory.py
@@ -23,8 +23,6 @@ import numpy as np
 import inspect
 import pytest
 
-from semantiva.payload_operations import DataNode
-from semantiva.examples.test_utils import DummyContext
 from semantiva_imaging.adapters.factory import _create_nchannel_processor
 from semantiva_imaging.processing.base_nchannel import NChannelImageOperation
 from semantiva_imaging.data_types import RGBImage, RGBAImage
@@ -118,13 +116,6 @@ def test_metadata_exposure():
     # Test parameter name extraction for pipeline integration
     names = AddRGBImageProcessor.get_processing_parameter_names()
     assert names == ["other_image", "scale"]
-
-    # Test integration with Semantiva's DataNode system
-    # This simulates how the processor would be used in a pipeline
-    node = DataNode(AddRGBImageProcessor)
-    ctx = DummyContext({"other_image": RGBImage(np.zeros((2, 2, 3))), "scale": 1.0})
-    params = node._get_processor_parameters(ctx)
-    assert set(params.keys()) == {"other_image", "scale"}
 
 
 def test_error_paths():

--- a/tests/test_pipeline_parametric_gaussian_fit_yaml.py
+++ b/tests/test_pipeline_parametric_gaussian_fit_yaml.py
@@ -1,0 +1,70 @@
+# Copyright 2025 Semantiva authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from semantiva.registry.plugin_registry import load_extensions
+from semantiva.configurations.load_pipeline_from_yaml import load_pipeline_from_yaml
+from semantiva.pipeline import Pipeline
+from semantiva_imaging.data_types import SingleChannelImageStack
+
+
+@pytest.fixture
+def yaml_config_path():
+    return "tests/pipeline_parametric_gaussian_fit.yaml"
+
+
+def test_yaml_pipeline_parametric_gaussian_fit(yaml_config_path):
+    load_extensions("semantiva_imaging")
+
+    pipeline_config = load_pipeline_from_yaml(yaml_config_path)
+    pipeline = Pipeline(pipeline_config)
+
+    payload_out = pipeline.process()
+    output_data, output_context = payload_out.data, payload_out.context
+
+    # Validate outputs exist in context
+    assert "gaussian_fit_parameters" in output_context.keys()
+    assert "std_dev_coefficients" in output_context.keys()
+    assert "orientation_coefficients" in output_context.keys()
+
+    # Coefficients should be arrays or sequences of length degree+1 (here 2)
+    std_coeffs = output_context.get_value("std_dev_coefficients")
+    orient_coeffs = output_context.get_value("orientation_coefficients")
+
+    assert hasattr(std_coeffs, "__len__") and len(std_coeffs) == 2
+    assert hasattr(orient_coeffs, "__len__") and len(orient_coeffs) == 2
+
+    # Ensure pipeline returns a stack (slicing should collect back to stack)
+    assert isinstance(output_data, SingleChannelImageStack)
+
+    # Validate fitted coefficients against expected parametric expressions
+    # From YAML config: std_dev = "(50 + 20 * t, 20)" -> std_dev_x = 50 + 20*t
+    # From YAML config: angle = "60 + 5 * t"
+
+    # Check std_dev coefficients: should be 50 (intercept) + 20 (slope) * t
+    assert (
+        abs(std_coeffs["coeff_0"] - 50.0) < 0.000001
+    ), f"std_dev coeff_0 {std_coeffs['coeff_0']} not close to 50.0"
+    assert (
+        abs(std_coeffs["coeff_1"] - 20.0) < 0.000001
+    ), f"std_dev coeff_1 {std_coeffs['coeff_1']} not close to 20.0"
+
+    # Check orientation coefficients: should be 60 (intercept) + 5 (slope) * t
+    assert (
+        abs(orient_coeffs["coeff_0"] - 60.0) < 0.000001
+    ), f"orientation coeff_0 {orient_coeffs['coeff_0']} not close to 60.0"
+    assert (
+        abs(orient_coeffs["coeff_1"] - 5.0) < 0.000001
+    ), f"orientation coeff_1 {orient_coeffs['coeff_1']} not close to 5.0"


### PR DESCRIPTION
- Bump semantiva dependency from 0.4.0 to upcoming 0.5.0
- Update terminology from "specialization" to "extension" throughout codebase
- Replace ImagingSpecialization with ImagingExtension class
- Update ComponentLoader to ClassRegistry for component registration
- Migrate from payload_operations.pipeline to pipeline module
- Update pipeline processing to use Payload wrapper objects
- Replace PipelineInspector with build_pipeline_inspection/summary_report
- Update load_specializations to load_extensions API
- Add new test for parametric Gaussian fitting pipeline with YAML config